### PR TITLE
Pin 294: Remove publish route

### DIFF
--- a/src/main/resources/interface-specification.yml
+++ b/src/main/resources/interface-specification.yml
@@ -114,45 +114,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/Problem'
   /eservices/{eServiceId}/descriptors/{descriptorId}:
-    post:
-      security:
-        - bearerAuth: [ ]
-      tags:
-        - e_service
-      summary: Publish a new descriptors
-      operationId: publishDescriptor
-      parameters:
-        - name: eServiceId
-          in: path
-          description: the eservice id
-          required: true
-          schema:
-            type: string
-        - name: descriptorId
-          in: path
-          description: the descriptor Id
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: EService Descriptor published
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/EService'
-        "400":
-          description: Invalid input
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Problem'
-        "404":
-          description: Not found
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Problem'
     patch:
       security:
         - bearerAuth: [ ]

--- a/src/main/scala/it/pagopa/pdnd/interop/uservice/catalogmanagement/model/CatalogDescriptor.scala
+++ b/src/main/scala/it/pagopa/pdnd/interop/uservice/catalogmanagement/model/CatalogDescriptor.scala
@@ -22,16 +22,8 @@ final case class CatalogDescriptor(
     )
   }
 
-  def isPublishable: Boolean = {
-    interface.isDefined && status == Draft
-  }
-
   def isDraft: Boolean = {
     status == Draft
-  }
-
-  def publish: CatalogDescriptor = {
-    copy(status = Published)
   }
 
 }

--- a/src/main/scala/it/pagopa/pdnd/interop/uservice/catalogmanagement/model/CatalogItem.scala
+++ b/src/main/scala/it/pagopa/pdnd/interop/uservice/catalogmanagement/model/CatalogItem.scala
@@ -52,14 +52,6 @@ final case class CatalogItem(
     copy(descriptors = updated)
   }
 
-  def publish(descriptorId: String): CatalogItem = {
-    val updated: Seq[CatalogDescriptor] = descriptors.map {
-      case descriptor if descriptor.id == UUID.fromString(descriptorId) => descriptor.publish
-      case descriptor                                                   => descriptor
-    }
-    copy(descriptors = updated)
-  }
-
   def getInterfacePath(descriptorId: String): Option[String] = {
     for {
       doc       <- descriptors.find(_.id == UUID.fromString(descriptorId))


### PR DESCRIPTION
This PR removes the route used to publish the descriptor.
This route will me moved in the `catalog-process` service in order to keep the management a simple CRUD service.