### PR TITLE
pin-310: Increase chunk size

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -30,6 +30,8 @@ akka {
       ask-timeout = 3 s
     }
   }
+
+  http.server.parsing.max-chunk-size=10M
 }
 
 datastax-java-driver {


### PR DESCRIPTION
This PR solves the error that occurs when uploading a file from process to management:
`HTTP chunk size exceeds the configured limit of 1048576 bytes`

As stated in [this](https://stackoverflow.com/a/39470686) response by an Akka developer, chunk size cannot be controlled by the application, so we can only work on server-side limits.
